### PR TITLE
Migrate to transparency-dev/merkle

### DIFF
--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -13,4 +13,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.48

--- a/api/verify/verify.go
+++ b/api/verify/verify.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/usbarmory/armory-drive-log/api"
-	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"golang.org/x/mod/sumdb/note"
 )
 

--- a/api/verify/verify_test.go
+++ b/api/verify/verify_test.go
@@ -21,8 +21,8 @@ import (
 	"testing"
 
 	"github.com/usbarmory/armory-drive-log/api"
-	"github.com/google/trillian/merkle/compact"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle/compact"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"golang.org/x/mod/sumdb/note"
 )
 

--- a/cmd/create_proofbundle/main.go
+++ b/cmd/create_proofbundle/main.go
@@ -22,18 +22,18 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
-	"github.com/usbarmory/armory-drive-log/api"
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/client"
 	"github.com/google/trillian/merkle/logverifier"
 	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/usbarmory/armory-drive-log/api"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -207,7 +207,7 @@ var getByScheme = map[string]func(context.Context, *url.URL) ([]byte, error){
 	"http":  readHTTP,
 	"https": readHTTP,
 	"file": func(_ context.Context, u *url.URL) ([]byte, error) {
-		return ioutil.ReadFile(u.Path)
+		return os.ReadFile(u.Path)
 	},
 }
 
@@ -224,7 +224,7 @@ func readHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
 
 	switch resp.StatusCode {
 	case 200:
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	case 404:
 		return nil, os.ErrNotExist
 	default:

--- a/cmd/create_proofbundle/main.go
+++ b/cmd/create_proofbundle/main.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/client"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle/proof"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/usbarmory/armory-drive-log/api"
 	"golang.org/x/mod/sumdb/note"
 )
@@ -111,7 +111,6 @@ func createBundle(ctx context.Context, logURL string, release []byte, lSigV note
 	}
 
 	leafHash := h.HashLeaf(release)
-	lv := logverifier.New(h)
 	// Wait for inclusion
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
@@ -146,7 +145,7 @@ func createBundle(ctx context.Context, logURL string, release []byte, lSigV note
 		if err != nil {
 			return nil, fmt.Errorf("failed to create inclusion proof for leaf %d: %v", idx, err)
 		}
-		if err := lv.VerifyInclusionProof(int64(idx), int64(cp.Size), ip, cp.Hash, leafHash); err != nil {
+		if err := proof.VerifyInclusion(h, idx, cp.Size, leafHash, ip, cp.Hash); err != nil {
 			return nil, fmt.Errorf("failed to verify inclusion proof: %q", err)
 		}
 		glog.Infof("Found leaf at %d", idx)

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -27,17 +27,17 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
 
-	"github.com/usbarmory/armory-drive-log/api"
-	"github.com/usbarmory/armory-drive-log/keys"
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/client"
 	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/usbarmory/armory-drive-log/api"
+	"github.com/usbarmory/armory-drive-log/keys"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -160,7 +160,7 @@ func (m *Monitor) From(ctx context.Context, start uint64) error {
 			return fmt.Errorf("handler(): %w", err)
 		}
 	}
-	return ioutil.WriteFile(m.stateFile, m.st.LatestConsistentRaw, 0644)
+	return os.WriteFile(m.stateFile, m.st.LatestConsistentRaw, 0644)
 }
 
 // stateTrackerFromFlags constructs a state tracker based on the flags provided to the main invocation.
@@ -171,7 +171,7 @@ func stateTrackerFromFlags(ctx context.Context) (client.LogStateTracker, bool, e
 		return client.LogStateTracker{}, false, errors.New("--state_file required")
 	}
 
-	state, err := ioutil.ReadFile(*stateFile)
+	state, err := os.ReadFile(*stateFile)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return client.LogStateTracker{}, false, fmt.Errorf("could not read state file %q: %w", *stateFile, err)
@@ -213,6 +213,6 @@ func newFetcher(root *url.URL) (client.Fetcher, error) {
 			return nil, err
 		}
 		defer resp.Body.Close()
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}, nil
 }

--- a/cmd/monitor/main.go
+++ b/cmd/monitor/main.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian-examples/serverless/client"
-	"github.com/google/trillian/merkle/rfc6962"
+	"github.com/transparency-dev/merkle/rfc6962"
 	"github.com/usbarmory/armory-drive-log/api"
 	"github.com/usbarmory/armory-drive-log/keys"
 	"golang.org/x/mod/sumdb/note"

--- a/cmd/monitor/verify.go
+++ b/cmd/monitor/verify.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,15 +18,14 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/usbarmory/armory-drive-log/api"
 	"github.com/usbarmory/armory-drive-log/keys"
-	"github.com/golang/glog"
 )
 
 const (
@@ -121,7 +120,7 @@ func (v *ReproducibleBuildVerifier) VerifyManifest(ctx context.Context, i uint64
 	}
 
 	// Hash the firmware artifact.
-	data, err := ioutil.ReadFile(filepath.Join(repoRoot, api.FirmwareArtifactName))
+	data, err := os.ReadFile(filepath.Join(repoRoot, api.FirmwareArtifactName))
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %v", api.FirmwareArtifactName, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.16
 require (
 	github.com/golang/glog v0.0.0-20210429001901-424d2337a529
 	github.com/google/go-cmp v0.5.6
-	github.com/google/trillian v1.3.14-0.20210902135231-6ff130e23e0c
+	github.com/google/trillian v1.3.14-0.20210902135231-6ff130e23e0c // indirect
 	github.com/google/trillian-examples v0.0.0-20210909165703-c62749b7931e
+	github.com/transparency-dev/merkle v0.0.1
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/mod v0.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -200,7 +200,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.3.0-java/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/etcd-io/gofail v0.0.0-20190801230047-ad7f989257ca/go.mod h1:49H/RkXP8pKaZy4h0d+NW16rSLhyVBt4o6VLJbmOqDE=
-github.com/f-secure-foundry/tamago v0.0.0-20201201222556-c7d3ba598c56 h1:HH3Y8V0tIqE/ZgzqwvZ8BF868LdhjlJkFjXdnArk6DU=
 github.com/f-secure-foundry/tamago v0.0.0-20201201222556-c7d3ba598c56/go.mod h1:+xmhdYxGfaNhWUZ/F1mbwFu38H73slg/k/oPjOL7tc8=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
@@ -662,6 +661,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
+github.com/transparency-dev/merkle v0.0.1 h1:T9/9gYB8uZl7VOJIhdwjALeRWlxUxSfDEysjfmx+L9E=
+github.com/transparency-dev/merkle v0.0.1/go.mod h1:B8FIw5LTq6DaULoHsVFRzYIUDkl8yuSwCdZnOZGKL/A=
 github.com/twitchyliquid64/golang-asm v0.0.0-20190126203739-365674df15fc/go.mod h1:NoCfSFWosfqMqmmD7hApkirIK9ozpHjxRnRxs1l413A=
 github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=


### PR DESCRIPTION
Use the new [merkle repo](https://github.com/transparency-dev/merkle) for doing proof verification.

The new repo is a much lighter-weight dependency.

