### PR TITLE
Use stable release artefact URL for source tarball

### DIFF
--- a/cmd/create_release/main.go
+++ b/cmd/create_release/main.go
@@ -27,8 +27,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/usbarmory/armory-drive-log/api"
 	"github.com/golang/glog"
+	"github.com/usbarmory/armory-drive-log/api"
 	"golang.org/x/mod/sumdb/note"
 )
 
@@ -50,7 +50,7 @@ func main() {
 		glog.Exitf("Invalid flag(s):\n%s", err)
 	}
 
-	sourceURL := fmt.Sprintf("https://github.com/%s/tarball/%s", *repo, *revisionTag)
+	sourceURL := fmt.Sprintf("https://github.com/%s/archive/refs/tags/%s.tar.gz", *repo, *revisionTag)
 	sourceHash, err := hashRemote(sourceURL)
 	if err != nil {
 		glog.Exitf("Failed to hash source tarball (%s): %v", sourceURL, err)


### PR DESCRIPTION
This PR changes the address from which source tarballs should be downloaded.

The URL previously used appears to produce dynamic tarball contents based on the _current_ org and repo name rather than the org and repo name as of the time the release was created - the tarball contains a top level directory which seems to be built like so: `<org-name>-<repo-name>-<hash>/...`.

Fetching the old style URL results in a string of redirects, ending in downloading the tarball as described above.

The new URL used in this PR produces a tarball with a top level directory of `<repo-name>-<release-tag>/...`

Example manifest with change:
```json
{
  "description": "test",
  "platform_id": "plat",
  "revision": "v2021.10.08",
  "artifact_sha256": {
    "armory-drive.csf": "9oQowJD1ta5XCpdmuRcTuwcG021b8Knadus2zFDdPrQ=",
    "armory-drive.imx": "2dJ4zYAsPXUnSVBWk/56yV3myfK2UdqQ+vtMUHYekus=",
    "armory-drive.sdp": "VCKs24PuKS0ov0LaC/YaHiCrsxZPhiMbO7+7eqqWvN0="
  },
  "source_url": "https://github.com/usbarmory/armory-drive/archive/refs/tags/v2021.10.08.tar.gz",
  "source_sha256": "AumOLlETZbold7ZxNiYdjOxlfoLHuKrEWw3LwhjsbQA=",
  "tool_chain": "tamago version go1.17.1 linux/amd64",
  "build_args": {
    "REV": "b90e2d9"
  }
}
```

source_sha256 verification:
```bash 
$ curl -L -s https://github.com/usbarmory/armory-drive/archive/refs/tags/v2021.10.08.tar.gz | openssl dgst -sha256 -binary | base64
AumOLlETZbold7ZxNiYdjOxlfoLHuKrEWw3LwhjsbQA=
```

and tarball contents:
```bash
$ curl -L -s https://github.com/usbarmory/armory-drive/archive/refs/tags/v2021.10.08.tar.gz | tar -tzvf - | head -10
drwxrwxr-x root/root         0 2021-10-08 08:27 armory-drive-2021.10.08/
-rw-rw-r-- root/root       518 2021-10-08 08:27 armory-drive-2021.10.08/LICENSE
-rw-rw-r-- root/root      7661 2021-10-08 08:27 armory-drive-2021.10.08/Makefile
-rw-rw-r-- root/root      7037 2021-10-08 08:27 armory-drive-2021.10.08/README.md
drwxrwxr-x root/root         0 2021-10-08 08:27 armory-drive-2021.10.08/api/
-rw-rw-r-- root/root       659 2021-10-08 08:27 armory-drive-2021.10.08/api/api.go
-rw-rw-r-- root/root      8596 2021-10-08 08:27 armory-drive-2021.10.08/api/armory.proto
drwxrwxr-x root/root         0 2021-10-08 08:27 armory-drive-2021.10.08/assets/
-rw-rw-r-- root/root      1215 2021-10-08 08:27 armory-drive-2021.10.08/assets/keys.go
drwxrwxr-x root/root         0 2021-10-08 08:27 armory-drive-2021.10.08/cmd/
```